### PR TITLE
Update qiskit examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Images
+*.png
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/qiskit/README.md
+++ b/qiskit/README.md
@@ -1,6 +1,6 @@
 # Helmi Qiskit Examples
 
-Examples made through Qiskit which are optimised for use on Helmi. These examples were made with the aim to show how simple quantum jobs can be run on Helmi and to also demonstate the differences in results between the simulator and the real quantum computer. Therefore each example has the option to run with a simulator or with the Quantum Computer, Helmi. Running jobs on Helmi requires submitting of jobs through SLURM with the `--partition q_fiqci` option.
+Examples made with Qiskit which are optimised for use on Helmi. These examples were made with the aim to show how simple quantum jobs can be run on Helmi and to demonstate the differences in results between the simulator and a real quantum computer. Therefore each example has the option to run with a simulator or with the Quantum Computer, Helmi. Running jobs on Helmi requires submitting of jobs through the LUMI supercomputer using SLURM with the `--partition q_fiqci` option. Alternatively one can access Helmi through the LUMI web interface, where it is possible to access Helmi from a Jupyter notebook enviroment.
 
 ## Example list
 
@@ -11,7 +11,7 @@ Examples made through Qiskit which are optimised for use on Helmi. These example
 | [Bernstein Vazirani]( #bernstein-vazirani)           | `bv.py`                 | `python bernstein_vazirani.py --backend helmi` |
 | [GHZ state]( #ghz-state)                             | `ghz.py`                | `python ghz.py --backend helmi`                |
 
-All examples have command line arguments which can be viewed with the `-h` or `--help` option. You can run the scripts with the `-h` option in the login node. Using this also prints some example usage for each example. Each example also has the verbose option built in, add the `-v` or `--verbose` command line argument.
+All examples have command line arguments which can be viewed with the `-h` or `--help` option. You can run the scripts with the `-h` option in the LUMI login node. Using this also prints some example usage for each example. Each example also has the verbose option built in, add the `-v` or `--verbose` command line argument.
 
 ## Running on LUMI
 
@@ -29,7 +29,7 @@ For interactive usage:
 srun --account project_xxx -t 00:15:00 -c 1 -n 1 --partition q_fiqci python -u qb_flip.py --backend helmi
 ```
 
-This will print the output to the terminal. The `-u` option enables constant updating of the output through python.
+This will print the output to the terminal. The `-u` option enables constant updating of the output in the terminal.
 
 
 As a batch script:
@@ -64,7 +64,7 @@ The `qb_flip_simple.py` is a simple version of the `qb_flip.py` code which runs 
 
 ### Bell State Entanglement
 
-The `bell_states_qiskit.py` creates a `|00> + |11> / sqrt(2)` bell state between different qubit pairs and entangling them. This example is a good emasure of how different qubit pairs interact and how utilising Helmi's topology gives better results. Each qubit pair (QB1&QB3 or QB2&QB3) contains one of the outer qubits (QB1, QB2, QB4, QB5) and the inner qubit QB3. The example creates a bell state by placing a hadamard gate on the outer qubit and a Controlled-X gate between the two qubits with a different control and target qubit each time. The example prints how often the correct bell state is measured and how often the `|00>` and `|11>` states exist, giving a mesure of noise.
+The `bell_states_qiskit.py` creates a `|00> + |11> / sqrt(2)` bell state between different qubit pairs and entangling them. This example is a good measure of how different qubit pairs interact and how utilising Helmi's topology gives better results. Each qubit pair (QB1&QB3 or QB2&QB3) contains one of the outer qubits (QB1, QB2, QB4, QB5) and the inner qubit QB3. The example creates a bell state by placing a hadamard gate on the outer qubit and a CNOT gate between the two qubits with a different control and target qubit each time. The example prints how often the correct bell state is measured and how often the `|00>` and `|11>` states exist, giving a mesure of noise.
 
 
 ### Bernstein Vazirani
@@ -96,14 +96,14 @@ qB_4: ────────────────╫───────�
 
 ```
 
-2-Qubit gates are placed on QB3 (Here this is qB_2 due to Qiskit indexing starting from 0) with the target of one of the outer qubits. We can now measure the fidelity and trace distance for this.
+2-Qubit gates are placed on QB3 (Here this is QB_2 due to Qiskit indexing starting from 0) with the target of one of the outer qubits. We can now measure the fidelity and trace distance for this.
 
 - Fidelity is the "closeness" of two quantum states or how distinguishable they are from each other
     - For example a maximum value of 1 is attained if and only if the two states are identical.
-    - There is good discussion found here: http://theory.caltech.edu/~preskill/ph219/chap2_15.pdf
+    - For more detailed explanation have a look at: http://theory.caltech.edu/~preskill/ph219/chap2_15.pdf
 
 - The "Distance from target" or the Trace Distance is the Quantum generalization of the "statistical distance"
-    or Kolmogorov distance
+    or Kolmogorov distance.
     It is another measure of the distinguishability between two quantum states
 
 

--- a/qiskit/advanced/getting_metadata.py
+++ b/qiskit/advanced/getting_metadata.py
@@ -14,7 +14,7 @@ backend = IQMFakeAdonis()
 HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
 if not HELMI_CORTEX_URL:
     print("Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi? Falling back to a simulator.")
-    #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+    # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
 else:
     provider = IQMProvider(HELMI_CORTEX_URL)
@@ -57,12 +57,19 @@ exp_result = result._get_experiment(circuit)
 print("Job ID: ", job.job_id(), end="\n")  # Retrieving the submitted job id
 
 try:
-    print("Circuits: ", job._circuits[0], end="\n")  # Retrieving the circuit request sent
-    print("Mapping: ", job.result().results[0].metadata['input_qubit_map'], end="\n")
+    # Retrieving the circuit request sent
+    print("Circuits: ", job._circuits[0], end="\n")
+    print(
+        "Mapping: ", job.result(
+        ).results[0].metadata['input_qubit_map'], end="\n",
+    )
 except AttributeError:
     print("Circuits: ", result.request.circuits, end="\n")
     print("Calibration Set ID: ", exp_result.calibration_set_id, end="\n")
-    print("Mapping: ", job.result().request.qubit_mapping, end="\n")  # Retrieving the qubit mapping
+    print(
+        "Mapping: ", job.result().request.qubit_mapping,
+        end="\n",
+    )  # Retrieving the qubit mapping
 # Retrieving the number of requested shots.
 print("Shots: ", result.results[0].shots, end="\n")
 

--- a/qiskit/advanced/getting_metadata.py
+++ b/qiskit/advanced/getting_metadata.py
@@ -3,13 +3,22 @@ This example demonstrates how to get metadata about your job submitted with Qisk
 """
 import os
 
-from qiskit_iqm import IQMProvider
+from iqm.qiskit_iqm import IQMProvider
+from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
 
 from qiskit import QuantumCircuit, transpile
 
+backend = IQMFakeAdonis()
+
+# Set up the Helmi backend
 HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
-provider = IQMProvider(HELMI_CORTEX_URL)
-backend = provider.get_backend()
+if not HELMI_CORTEX_URL:
+    print("Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi? Falling back to a simulator.")
+    #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+
+else:
+    provider = IQMProvider(HELMI_CORTEX_URL)
+    backend = provider.get_backend()
 
 # Retrieving backend information
 print(f'Native operations: {backend.operation_names}')
@@ -46,12 +55,16 @@ result = job.result()
 exp_result = result._get_experiment(circuit)
 
 print("Job ID: ", job.job_id(), end="\n")  # Retrieving the submitted job id
-print(result.request.circuits, end="\n")  # Retrieving the circuit request sent
-# Retrieving the current calibration set id.
-print("Calibration Set ID: ", exp_result.calibration_set_id, end="\n")
-print(result.request.qubit_mapping, end="\n")  # Retrieving the qubit mapping
+
+try:
+    print("Circuits: ", job._circuits[0], end="\n")  # Retrieving the circuit request sent
+    print("Mapping: ", job.result().results[0].metadata['input_qubit_map'], end="\n")
+except AttributeError:
+    print("Circuits: ", result.request.circuits, end="\n")
+    print("Calibration Set ID: ", exp_result.calibration_set_id, end="\n")
+    print("Mapping: ", job.result().request.qubit_mapping, end="\n")  # Retrieving the qubit mapping
 # Retrieving the number of requested shots.
-print(result.request.shots, end="\n")
+print("Shots: ", result.results[0].shots, end="\n")
 
 # retrieve a job using the job_id from a previous session
 # old_job = backend.retrieve_job(job_id)

--- a/qiskit/advanced/state-tomography.py
+++ b/qiskit/advanced/state-tomography.py
@@ -1,25 +1,40 @@
 """
+NOTE: This script is using qiskit-iqm 15.6, Qiskit 1.1.2 and qiskit-experiments 0.7.0.
+Using a newer version of qiskit-experiments will result in an error.
+You can install the required version of qiskit-experiments by running:
+
+python -m pip install qiskit-experiments==0.7.0
+
 An example of using the Qiskit experiments library on Helmi
-This example requires installing the qiskit-experiments package e.g,
-python -m pip install qiskit-experiments
 
 The StateTomography experiment creates a single job containing several circuits.
 As part of the analysis, the experiment estimates the density matrix of the state based on the results.
 
-This example does not show how to vizualize the results of the StateTomography experiment.
-
-Additional details on Qiskit Experiments can be found here: https://qiskit.org/ecosystem/experiments/
+Additional details on Qiskit Experiments can be found here: https://qiskit.org/ecosystem/experiments/ and
+more infot on the StateTomography experiment can be found here: https://github.com/qiskit-community/qiskit-experiments/blob/0.7.0/docs/manuals/verification/state_tomography.rst
 """
+
 import os
 
 from qiskit_experiments.library import StateTomography
-from qiskit_iqm import IQMProvider
+from iqm.qiskit_iqm import IQMProvider
+from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
 
 from qiskit import QuantumCircuit
+from qiskit.visualization import plot_state_city
 
+
+backend = IQMFakeAdonis()
+
+# Set up the Helmi backend
 HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
-provider = IQMProvider(HELMI_CORTEX_URL)
-backend = provider.get_backend()
+if not HELMI_CORTEX_URL:
+    print("Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi? Falling back to a simulator.")
+    #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+
+else:
+    provider = IQMProvider(HELMI_CORTEX_URL)
+    backend = provider.get_backend()
 
 circuit = QuantumCircuit(2, name='Bell pair circuit')
 circuit.h(0)
@@ -35,11 +50,12 @@ print(tomography_circuit.circuits()[0].metadata)
 
 tomography_data = tomography_circuit.run(
     backend, seed_simulation=42, shots=100,
-)
+).block_for_results()
 jobs = tomography_data.jobs()
 print(jobs)
 print(jobs[0].status())
 
-tomography_data = tomography_data.block_for_results()
-for result in tomography_data.analysis_results():
-    print(result)
+
+state_result = tomography_data.analysis_results("state")
+print(state_result)
+plot_state_city(state_result.value, title="Density Matrix", filename="density_matrix.png")

--- a/qiskit/advanced/state-tomography.py
+++ b/qiskit/advanced/state-tomography.py
@@ -11,18 +11,18 @@ The StateTomography experiment creates a single job containing several circuits.
 As part of the analysis, the experiment estimates the density matrix of the state based on the results.
 
 Additional details on Qiskit Experiments can be found here: https://qiskit.org/ecosystem/experiments/ and
-more infot on the StateTomography experiment can be found here: https://github.com/qiskit-community/qiskit-experiments/blob/0.7.0/docs/manuals/verification/state_tomography.rst
+more infot on the StateTomography experiment can be found here:
+https://github.com/qiskit-community/qiskit-experiments/blob/0.7.0/docs/manuals/verification/state_tomography.rst
 """
 
 import os
 
-from qiskit_experiments.library import StateTomography
 from iqm.qiskit_iqm import IQMProvider
 from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
+from qiskit_experiments.library import StateTomography
 
 from qiskit import QuantumCircuit
 from qiskit.visualization import plot_state_city
-
 
 backend = IQMFakeAdonis()
 
@@ -30,7 +30,7 @@ backend = IQMFakeAdonis()
 HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
 if not HELMI_CORTEX_URL:
     print("Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi? Falling back to a simulator.")
-    #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+    # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
 else:
     provider = IQMProvider(HELMI_CORTEX_URL)
@@ -58,4 +58,7 @@ print(jobs[0].status())
 
 state_result = tomography_data.analysis_results("state")
 print(state_result)
-plot_state_city(state_result.value, title="Density Matrix", filename="density_matrix.png")
+plot_state_city(
+    state_result.value, title="Density Matrix",
+    filename="density_matrix.png",
+)

--- a/qiskit/bell_state.ipynb
+++ b/qiskit/bell_state.ipynb
@@ -2,37 +2,75 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "from iqm.qiskit_iqm import IQMProvider\n",
+    "from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis\n",
     "from qiskit.compiler import transpile\n",
-    "from qiskit import QuantumCircuit\n",
+    "from qiskit import QuantumCircuit, transpile\n",
     "from qiskit.visualization import plot_histogram"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.\n"
+     ]
+    }
+   ],
    "source": [
     "# Set up the Helmi backend\n",
+    "backend = IQMFakeAdonis()\n",
     "HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')\n",
     "if not HELMI_CORTEX_URL:\n",
-    "\traise ValueError(\"Environment variable HELMI_CORTEX_URL is not set\")\n",
+    "    print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')\n",
+    "\t#raise ValueError(\"Environment variable HELMI_CORTEX_URL is not set\")\n",
     "\n",
-    "provider = IQMProvider(HELMI_CORTEX_URL)\n",
-    "backend = provider.get_backend()"
+    "else:\n",
+    "    provider = IQMProvider(HELMI_CORTEX_URL)\n",
+    "    backend = provider.get_backend()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">        ┌───┐      ░ ┌─┐   \n",
+       "   q_0: ┤ H ├──■───░─┤M├───\n",
+       "        └───┘┌─┴─┐ ░ └╥┘┌─┐\n",
+       "   q_1: ─────┤ X ├─░──╫─┤M├\n",
+       "             └───┘ ░  ║ └╥┘\n",
+       "meas: 2/══════════════╩══╩═\n",
+       "                      0  1 </pre>"
+      ],
+      "text/plain": [
+       "        ┌───┐      ░ ┌─┐   \n",
+       "   q_0: ┤ H ├──■───░─┤M├───\n",
+       "        └───┘┌─┴─┐ ░ └╥┘┌─┐\n",
+       "   q_1: ─────┤ X ├─░──╫─┤M├\n",
+       "             └───┘ ░  ║ └╥┘\n",
+       "meas: 2/══════════════╩══╩═\n",
+       "                      0  1 "
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Create a bell state: \n",
     "qc = QuantumCircuit(2)\n",
@@ -45,30 +83,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">global phase: 3π/2\n",
+       "               ┌────────────┐┌────────┐                            ░ ┌─┐   \n",
+       "      q_0 -> 0 ┤ R(π/2,π/2) ├┤ R(π,0) ├─■──────────────────────────░─┤M├───\n",
+       "               └────────────┘└────────┘ │                          ░ └╥┘   \n",
+       "ancilla_0 -> 1 ─────────────────────────┼─────────────────────────────╫────\n",
+       "               ┌────────────┐┌────────┐ │ ┌────────────┐┌────────┐ ░  ║ ┌─┐\n",
+       "      q_1 -> 2 ┤ R(π/2,π/2) ├┤ R(π,0) ├─■─┤ R(π/2,π/2) ├┤ R(π,0) ├─░──╫─┤M├\n",
+       "               └────────────┘└────────┘   └────────────┘└────────┘ ░  ║ └╥┘\n",
+       "ancilla_1 -> 3 ───────────────────────────────────────────────────────╫──╫─\n",
+       "                                                                      ║  ║ \n",
+       "ancilla_2 -> 4 ───────────────────────────────────────────────────────╫──╫─\n",
+       "                                                                      ║  ║ \n",
+       "       meas: 2/═══════════════════════════════════════════════════════╩══╩═\n",
+       "                                                                      0  1 </pre>"
+      ],
+      "text/plain": [
+       "global phase: 3π/2\n",
+       "               ┌────────────┐┌────────┐                            ░ ┌─┐   \n",
+       "      q_0 -> 0 ┤ R(π/2,π/2) ├┤ R(π,0) ├─■──────────────────────────░─┤M├───\n",
+       "               └────────────┘└────────┘ │                          ░ └╥┘   \n",
+       "ancilla_0 -> 1 ─────────────────────────┼─────────────────────────────╫────\n",
+       "               ┌────────────┐┌────────┐ │ ┌────────────┐┌────────┐ ░  ║ ┌─┐\n",
+       "      q_1 -> 2 ┤ R(π/2,π/2) ├┤ R(π,0) ├─■─┤ R(π/2,π/2) ├┤ R(π,0) ├─░──╫─┤M├\n",
+       "               └────────────┘└────────┘   └────────────┘└────────┘ ░  ║ └╥┘\n",
+       "ancilla_1 -> 3 ───────────────────────────────────────────────────────╫──╫─\n",
+       "                                                                      ║  ║ \n",
+       "ancilla_2 -> 4 ───────────────────────────────────────────────────────╫──╫─\n",
+       "                                                                      ║  ║ \n",
+       "       meas: 2/═══════════════════════════════════════════════════════╩══╩═\n",
+       "                                                                      0  1 "
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "transpiled_circuit = transpile(qc, backend, optimization_level=3)\n",
+    "transpiled_circuit = transpile(qc, backend, layout_method='sabre', optimization_level=3)\n",
     "transpiled_circuit.draw()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
     "job = backend.run(transpiled_circuit, shots=1000)\n",
     "result = job.result()\n",
-    "counts = result.get_counts()"
+    "counts = result.get_counts()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAGkCAYAAADZp5o/AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAALJ9JREFUeJzt3Qd0VGX6x/EnISHUEHqRrixFwFCkKlIiEaIUwbYsIrKgHORQFkSUspQ1FBVWBWFRmoK46AGFRYpUadKMIAoLLG3pkE1CDaT8z/P+vXMyYRIjJsxk3u/nnDmTvPcmc99778z9zfu+996A1NTUVAEAALBIoLcXAAAA4G4jAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWCfI2wvgq1JSUuT06dNSuHBhCQgI8PbiAACALNDLG16+fFnKlSsngYEZt/MQgDKg4adChQreXgwAAHAHTp48KeXLl89wOgEoA9ry46zA0NBQby8OAADIgoSEBNOA4RzHM0IAyoDT7aXhhwAEAEDu8mvDVxgEDQAArEMAAgAA1iEAAQDgZyZMmGC6gAYOHOgqa9mypSlL+3j55Zc9/v2lS5fMAGKdJy4uTvwRY4AAAPAjO3fulJkzZ0rdunVvm9a7d28ZO3as6/cCBQp4/B+9evUyf3/q1CnxV7QAAQDgJ65cuSLdunWTWbNmSdGiRW+broGnTJkyroenk3w++OAD0+ozZMgQ8WcEIAAA/ES/fv0kKipKIiIiPE5fsGCBlChRQmrXri3Dhw+Xa9euuU3/6aefTAvR/PnzM72IoD/w79pZylPfb9orZLZr185MX7p06W3Npm3atJGwsDDzzSEyMlJ++OGHu7jkAIA7tWjRItmzZ49ER0d7nP7HP/5RPvnkE1m/fr0JPx9//LH86U9/ck1PTEyU5557TiZPniwVK1YUf8cYIIv6ftXUqVM9XhtBm00fe+wx6dChg0yfPl2SkpJk9OjRJgTpxSCDg4PvwtIDAO6Efk4PGDBA1qxZI/ny5fM4T58+fVw/16lTR8qWLWu+9B45ckTuvfdeE4pq1qzpFor8GS1AFvX9xsTEyNtvvy2zZ8++bdqBAwckNjbWNH1Wr15d7r//fhOAzp07J8ePH79LNQAA3Indu3fL+fPnpX79+hIUFGQeGzdulHfffdf8nJycfNvfNG7c2DwfPnzYPK9bt04WL17s+nsNR0q7zPR44G8IQJb0/Wo/rzZ/Tps2zQx8S09DT/HixeWjjz6SmzdvyvXr183P+m2gcuXKd6kGAIA7oWFl37595ouu82jYsKH5Uqw/58mT57a/iYmJMc/aEqS++OILM+zB+fsPP/zQlH/77bfm+OJv6ALzs75f7QLzZNCgQdKsWTPp2LGjx+l6z5QNGzZIp06dZNy4caasWrVqsmrVKvNNAADgu/QzXAc2p1WwYEHzxVbLtZtr4cKF0r59e1O2d+9ec1xo0aKFa8iEdoOldfHiRfOsX4R1bKi/4chmQd/vV199ZZo2v//++wz/h7b46HUfmjdvLp9++qlpLn3rrbdMi5KGqvz58+dwLQAAOSVv3rzyzTffmHGgV69eNTcL7dKli4wYMUJsFZCqpwXB491kixQpIvHx8T5/M1Q9m6tz585uTZwaYHSws57G2LdvX9P1lfaURp2uvz/88MOm5Ue7u15//XU5c+aMaz7tCtOxRDrt2Wef9UrdAADIieM3LUB+1PebVs+ePaVGjRoybNgwM4DtpZdecpuuZwBMmTJFnnjiCdcYIQ0+ac8Qc35PSUm5SzUBAODuIABZ0PerPA181us8VKlSxfz86KOPytChQ81At/79+5vQo9cT0vE/rVq1uks1AQDg7uAsMBjaWrRs2TIzMK5p06ama+z06dOycuVK1xkCAAD4C8YA+cEYIAAA8NuO37QAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1CEAAAMA6BCAAAGAdAhAAALAOAQgAAFgnyNsLAACAjSq/9i+x2bEJUV59fVqAAACAdQhAAADAOgQgAABgHcYAeYHt/b6+0PcLALAbLUAAAMA6BCAAAGAdAhAAALAOAQgAAFiHAAQAAKxDAAIAANYhAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWIcABAAArEMAAgAA1iEAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1CEAAAMA6BCAAAGAdAhAAALAOAQgAAFiHAAQAAKxDAAIAANYhAAEAAOv4dACaMGGCBAQEyMCBA11lN27ckH79+knx4sWlUKFC0qVLFzl37pzb3504cUKioqKkQIECUqpUKRk6dKgkJSV5oQYAAMAX+WwA2rlzp8ycOVPq1q3rVj5o0CBZtmyZLF68WDZu3CinT5+WJ5980jU9OTnZhJ+bN2/K1q1bZd68eTJ37lwZNWqUF2oBAAB8kU8GoCtXrki3bt1k1qxZUrRoUVd5fHy8fPTRR/LOO+9I69atpUGDBjJnzhwTdLZv327mWb16tfz000/yySefSHh4uLRr107GjRsn06ZNM6EIAAAgSHyQdnFpK05ERISMHz/eVb579265deuWKXfUqFFDKlasKNu2bZMmTZqY5zp16kjp0qVd80RGRkrfvn1l//79Uq9ePY+vmZiYaB6OhIQE86yvpw8VGBgoefLkMa1MKSkprnmdcu1mS01NdZVrmU5LXw5xrY/0XZPBwcFm3eo6dmg3aFBQUIblGW2P37udnHJn+zv0NT0te0bl1Ik6USfqlFm5rW79st5yYjvlygC0aNEi2bNnj+kCS+/s2bOSN29eCQsLcyvXsKPTnHnShh9nujMtI9HR0TJmzJjbyrVFSccSKQ1aGqD27t1rxhk5qlevboLYjh075MKFC65ybYGqVKmSbNq0SS5fvuzLq/2u0x30+vXrsn79eleZvgE0+F68eNEEWUfhwoVNi9/JkyclJibGVV6yZElp1qyZHDp0SA4ePOgqz67t1LRpUzOGTPeBtG+oVq1aSf78+WXFihVudWrfvj11ok7UiTr9hjrZfSxY8cv6ye7ttGXLliy9fkCqDzVN6M7bsGFDWbNmjWvsT8uWLU2lpk6dKgsXLpSePXu6tdSoRo0amR1u4sSJ0qdPHzl+/LisWrXKNf3atWtSsGBBs7K1SyyrLUAVKlQwb7TQ0NBs/dZQbeRqsd3R6PbWfLujTtSJOlEnT+W2HwsOjWubI9spNjbWnCilw2ac47cnPhU/tYvr/PnzUr9+fVeZVlxT9/vvv29CjY7jiYuLc2sF0rPAypQpY37WZ02FaTlniTnzeBISEmIe6embTR9p6UrWR3rOzp3VcpvpDq/Sr1ulO7A+slqe0fbIru3kaRl/azl1ok6ZLTt1ok42Cs7isTWnjrk+NQi6TZs2sm/fPtOE6Ty0RUgHRDs/6wpbu3at62+0uUybxrQpUumz/g8NUg5tUdIUWKtWLa/UCwAA+BafaprQftzatWu7lWnXlTZlOeW9evWSwYMHS7FixUyo6d+/vwk9OgBatW3b1gSd7t27y6RJk8y4nxEjRpiB1Z5aeAAAgH18KgBlxZQpU0wTp14AUcfs6Ble06dPd03XZrLly5ebs740GGmA6tGjh4wdO9aryw0AAHyHzwegDRs2uP2eL18+c00ffWRER4GnH30PAADgk2OAAAAA7gYCEAAAsA4BCAAAWIcABAAArEMAAgAA1iEAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1CEAAAMA6BCAAAGAdAhAAALAOAQgAAFiHAAQAAKxDAAIAANYhAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWIcABAAArEMAAgAA1iEAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1CEAAAMA6BCAAAGAdAhAAALAOAQgAAFiHAAQAAKxDAAIAANYhAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWIcABAAArEMAAgAA1iEAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1fC4AffDBB1K3bl0JDQ01j6ZNm8rXX3/tmn7jxg3p16+fFC9eXAoVKiRdunSRc+fOuf2PEydOSFRUlBQoUEBKlSolQ4cOlaSkJC/UBgAA+CKfC0Dly5eXCRMmyO7du2XXrl3SunVr6dixo+zfv99MHzRokCxbtkwWL14sGzdulNOnT8uTTz7p+vvk5GQTfm7evClbt26VefPmydy5c2XUqFFerBUAAPAlAampqani44oVKyaTJ0+Wrl27SsmSJWXhwoXmZ3XgwAGpWbOmbNu2TZo0aWJaix5//HETjEqXLm3mmTFjhgwbNkwuXLggefPmzdJrJiQkSJEiRSQ+Pt60RGWnyq/9S2x3bEKUtxcBALzK9mPBsRw6DmT1+B0kPkxbc7Sl5+rVq6YrTFuFbt26JREREa55atSoIRUrVnQFIH2uU6eOK/yoyMhI6du3r2lFqlevnsfXSkxMNI+0K1Dp6+lDBQYGSp48ecxypaSkuOZ1yrWbLW2e1DKdlr4c4lof6bsmg4ODzbrVdewICAiQoKCgDMsz2h6/dzs55c72d+hrelr2jMqpE3WiTtQps3Jb3fplveXEdsoKnwxA+/btM4FHx/voOJ8lS5ZIrVq1JCYmxrTghIWFuc2vYefs2bPmZ31OG36c6c60jERHR8uYMWNuK1+9erUZS6Q0aGmA2rt3rxln5KhevboJYjt27DCtTI7w8HCpVKmSbNq0SS5fvuzrq/2u0h30+vXrsn79eleZvgG0+/LixYsmyDoKFy5sukJPnjxp9gGHtgY2a9ZMDh06JAcPHnSVZ9d20n1Qx5DpPpD2DdWqVSvJnz+/rFixwq1O7du3p07UiTpRp99QJ7uPBSt+WT/ZvZ22bNmSe7vAdPyOVlabrz7//HP58MMPzXgf3bF79uzp1lKjGjVqZHa4iRMnSp8+feT48eOyatUq1/Rr165JwYIFzcpu165dlluAKlSoYN5oThNadn1rqDZytdjuaHR7a77dUSfqRJ2ok6dy248Fh8a1zZHtFBsba06UypVdYNrKc99995mfGzRoIDt37pS///3v8swzz5hwFBcX59YKpGeBlSlTxvysz5oK03LOEnPm8SQkJMQ80tM3mz7S0pWsj/ScnTur5TbTHV6lX7dKd2B9ZLU8o+2RXdvJ0zL+1nLqRJ0yW3bqRJ1sFJzFY2tOHXN97iwwTzT5aeuMhiFdYWvXrnVN0+YybS3Spkilz9qFdv78edc8a9asMSlQu9EAAAB8rmli+PDhpptK+/60r1XP+NqwYYPp0tJR3b169ZLBgwebM8M01PTv39+EHh0Ardq2bWuCTvfu3WXSpElm3M+IESPMtYM8tfAAAAD7+FwA0pab559/Xs6cOWMCj14UUcPPo48+aqZPmTLFNHHqBRC1VUjP8Jo+fbrr77WZbPny5easLw1GOvanR48eMnbsWC/WCgAA+BKfHATtC7gOUM7iOkAAbGf7seCYl68DlCvGAAEAAGQnAhAAALAOAQgAAFiHAAQAAKxDAAIAANa54wCk90RJe28OT/S+LDofAACAXwQgvffW3LlzM51n/vz5Zj4AAAC/CEBZuXyQ3sLCuecTAACAFWOA9Nb2ejEiAACAXHsrjBdffNHt96VLl8qxY8dum09vXe+M/9H7egEAAOTaAJR2zI92bcXExJiHJzr9wQcfNPfuAgAAyLUB6OjRo67xP1WrVpWBAwfKgAEDbptPb0hatGhRcyNSAACAXB2AKlWq5Pp5zpw5Uq9ePbcyAAAAvwtAafXo0SN7lwQAAMDXA5Bjx44dsnPnTomLizODnz2NBRo5cuTvfRkAAADvB6DY2Fjp1KmTbNmyJdNrAhGAAACA3wSgwYMHy+bNm6Vly5amO6x8+fISFPS7G5QAAABy3B0nluXLl0ujRo1k7dq1XO0ZAADYcSXo69evS4sWLQg/AADAngAUHh7u8SrQAAAAfhuARo8eLV999ZVs3749e5cIAADAV8cAnT17VqKiouSRRx6Rbt26Sf369SU0NNTjvM8///zvWUYAAADfCEAvvPCCGf+jp8DrPcL0kX48kE7TMgIQAADwiwCkt8IAAADIjbgVBgAAsM4dD4IGAACwrgXoxIkTWZ63YsWKd/oyAAAAvhOAKleunKWLIOo8SUlJd/oyAAAAvhOA9MwuTwEoPj5efvjhBzl69Kg5RV6DEgAAgF8EID3tPSN6+vvbb78tkyZNko8++uhOXwIAACD3DILWlqEhQ4bI/fffL0OHDs2JlwAAAPDNs8AaNmwo69aty8mXAAAA8K0AdOTIEQZAAwAA/xkDlJGUlBQ5deqUGSP05ZdfSps2bbL7JQAAALwTgAIDAzM9DV4HQhctWtQMhgYAAPCLANSiRQuPAUiDkQafBx98UHr27CmlSpX6vcsIAADgGwFow4YN2bskAAAAdwn3AgMAANbJlkHQW7ZskZiYGElISJDQ0FAJDw+X5s2bZ8e/BgAA8K0AtHXrVjPO5/Dhw66Bz864oGrVqsmcOXOkadOm2bOkAAAA3g5A+/fvl7Zt28q1a9fk0UcflVatWknZsmXl7Nmzsn79elm9erVERkbK9u3bpVatWtm1vAAAAN4LQGPHjpWbN2/KihUr5LHHHnObNmzYMFm5cqV06NDBzLdo0aLfv6QAAADeHgStZ4F17dr1tvDj0HKdrq1BAAAAfhGA4uPjpUqVKpnOo9N1PgAAAL8IQOXKlTPjezLz3XffmfkAAAD8IgDp+B7tBhs5cqTcuHHDbZr+Pnr0aNP91bFjx+xYTgAAAO8Pgtbgs3z5cnnzzTdl5syZ0qhRIyldurScO3dOdu7cKRcuXJCqVaua+QAAAPwiABUvXtx0gb366qvmLC89G8yRL18+c32giRMnSrFixbJrWQEAALx/IcQSJUrI7NmzTQvQgQMHXFeCrlGjhgQHB2fPEgIAAHg7AP3tb3+Tq1evypgxY1whR5/r1KnjmkevD/TGG29I4cKF5bXXXsveJQYAALibg6C/+eYbGTVqlOn+yqyFJ2/evGYeDUFcBwgAAOTqADR//nwpWrSovPLKK786b79+/cz4H70fGAAAQK4NQHrz04iICAkJCfnVeXUenVfvFA8AAJBrA9Dp06fNqe1ZpVeCPnPmzJ0sFwAAgG8EoMDAQLl161aW59d59W8AAAB8yW9KJ3pbix9//DHL8+u899xzz50sFwAAgG8EoIcffljWrVsnx44d+9V5dR6dt0WLFr9n+QAAALwbgPTMLu3W6tq1q1y8eDHD+S5duiRPPfWUJCUlSd++fbNjOQEAALxzIcT69evLwIEDZerUqVKrVi15+eWXpVWrVlK+fHkz/dSpU7J27Vr5xz/+Ye4FNnjwYPM3AAAAufpK0G+//ba519fkyZPNVaH1kVZqaqrkyZNHhg8fLuPHj8/OZQUAAPBOAAoICDB3gO/Vq5e5yKFeG+js2bNmWpkyZaR58+bywgsvyL333ps9SwgAAOArN0PVgEMLDwAAyI24SA8AALCOzwWg6OhoefDBB82d5EuVKiWdOnWSgwcPus1z48YNc0aa3nC1UKFC0qVLFzl37pzbPCdOnJCoqCgpUKCA+T9Dhw41Z6UBAAD4XADauHGjCTfbt2+XNWvWmNPu27ZtK1evXnXNM2jQIFm2bJksXrzYzK+36HjyySdd05OTk034uXnzphmjNG/ePJk7d665kz0AAEBAqp625cP0dHptwdGgoxdVjI+Pl5IlS8rChQvN9YjUgQMHpGbNmrJt2zZp0qSJfP311/L444+bYFS6dGkzz4wZM2TYsGHm/+XNm/dXXzchIUGKFCliXi80NDRb61T5tX+J7Y5NiPL2IgCAV9l+LDiWQ8eBrB6/73gQ9N2iFVDFihUzz7t37zatQnqneUeNGjWkYsWKrgCkz3Xq1HGFHxUZGWkuyrh//36pV6/eba+TmJhoHmlXoNLXcu5/pvc101P8tYUpJSXFNa9Trl1safOklum09OX4/8slqPTdksHBwWbd6jpOe+ZhUFBQhuUZbY/fu52c8vT3v9PX9LTsGZVTJ+pEnahTZuW2uvXLesuJ7ZQVPh2AtMJ64UU9tb527dqmTE+51xacsLAwt3k17Din4+tz2vDjTHemZTT2aMyYMbeVr1692owjUhqyNDzt3bvXjDFyVK9e3YSwHTt2mBYmR3h4uFSqVEk2bdokly9fzi2r/a7QHfT69euyfv16V5m+AbTrUq8yriHWoePBWrduLSdPnpSYmBhXubYENmvWTA4dOuQ2Tiy7tlPTpk1N66PuA2nfUHrxz/z588uKFSvc6tS+fXvqRJ2oE3X6DXWy+1iw4pf1k93bacuWLbm/C0xbbLQ7a/Pmza6rTWvXV8+ePd1aa1SjRo3MTjdx4kTp06ePHD9+XFatWuWafu3aNSlYsKBZ4e3atctSC1CFChXMG81pQsuubw3VRq4W2x2Nbm/NtzvqRJ2oE3XyVG77seDQuLY5sp1iY2PNSVK5tgvslVdekeXLl5vE7YQf52KLOrg5Li7OrRVIzwLTac48mgzTcs4Sc+ZJLyQkxDzS0zebPtLSlayP9JydO6vlNtMdXqVft0p3YH1ktTyj7ZFd28nTMv7WcupEnTJbdupEnWwUnMVja04dc33uLDBNcxp+lixZYu4mX6VKFbfpDRo0MCtN7znm0CYzbR7T5kilz/v27ZPz58+75tEzyjQJ6j3MAACA3XyuaUJPgdduri+//NL06zpjdnREt/ap6rPehkNvtKoDozXU9O/f34QeHQCt9LR5DTrdu3eXSZMmmf8xYsQI8789tfIAAAC7+FwA+uCDD8xzy5Yt3cr1vmN6jzE1ZcoU08ypF0DUcTt6htf06dNd82pTmXaf6RgiDUY69qdHjx4yduzYu1wbAADgi3wuAGVlTLbejX7atGnmkREdCZ5+BD4AAIBPjgECAADIaQQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1CEAAAMA6BCAAAGAdAhAAALAOAQgAAFiHAAQAAKxDAAIAANYhAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWIcABAAArEMAAgAA1iEAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1CEAAAMA6BCAAAGAdAhAAALAOAQgAAFiHAAQAAKxDAAIAANYhAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWIcABAAArEMAAgAA1iEAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1CEAAAMA6BCAAAGAdAhAAALAOAQgAAFiHAAQAAKxDAAIAANYhAAEAAOv4XADatGmTPPHEE1KuXDkJCAiQpUuXuk1PTU2VUaNGSdmyZSV//vwSEREhhw4dcpsnNjZWunXrJqGhoRIWFia9evWSK1eu3OWaAAAAX+VzAejq1avywAMPyLRp0zxOnzRpkrz77rsyY8YM+e6776RgwYISGRkpN27ccM2j4Wf//v2yZs0aWb58uQlVffr0uYu1AAAAvixIfEy7du3MwxNt/Zk6daqMGDFCOnbsaMrmz58vpUuXNi1Fzz77rPz888+ycuVK2blzpzRs2NDM895770n79u3lrbfeMi1LAADAbj4XgDJz9OhROXv2rOn2chQpUkQaN24s27ZtMwFIn7Xbywk/SucPDAw0LUadO3f2+L8TExPNw5GQkGCeb926ZR5K/0eePHkkOTlZUlJSXPM65UlJSSakObRMp6Uvx/+HWaXrJq3g4GCzbnUdO7QrNCgoKMPyjLbH791OTrmz/R36mp6WPaNy6kSdqBN1yqzcVrd+WW85sZ38LgBp+FHa4pOW/u5M0+dSpUq5TdcVW6xYMdc8nkRHR8uYMWNuK1+9erUUKFDA/FyxYkWpV6+e7N27V06cOOGap3r16lKjRg3ZsWOHXLhwwVUeHh4ulSpVMl1wly9fTrtEYjvdQa9fvy7r1693205RUVFy8eJFE2QdhQsXltatW8vJkyclJibGVV6yZElp1qyZGQN28OBBV3l2baemTZuafUn3gbRvqFatWpnxZytWrHCrk7YyUifqRJ2oU9brZPexYMUv6ye7t9OWLVuy9PoBqT7cNKGpcMmSJdKpUyfz+9atW6V58+Zy+vRpMwja8fTTT5t5P/vsM3nzzTdl3rx5bitR6U6qAadv375ZbgGqUKGCeaPpYOrs/NZQbeRqsd3R6PbWfLujTtSJOlEnT+W2HwsOjWubI9tJT4QqXry4xMfHu47fnuSq+FmmTBnzfO7cObcApL9r8nPmOX/+vNvf6UrSFeL8vSchISHmkZ6+2fSRlq5kfaTn7NxZLbeZ7vAq/bpVugPrI6vlGW2P7NpOnpbxt5ZTJ+qU2bJTJ+pko+AsHltz6pjrc2eBZaZKlSomxKxdu9atpUbH9mhTpNLnuLg42b17t2uedevWmfSoY4UAAAB8rmlCr9dz+PBht4HP2qerY3i0P3DgwIEyfvx4qVatmglEI0eONGd2Od1kNWvWlMcee0x69+5tTpXXpslXXnnFDJDmDDAAAOCTAWjXrl1mAJlj8ODB5rlHjx4yd+5cefXVV821gvS6PtrS89BDD5nT3vPly+f6mwULFpjQ06ZNG9Mc2qVLF3PtIAAAAJ8fBO1N2rWmp9j/2iCqO1H5tX+J7Y5NiPL2IgCAV9l+LDiWQ8eBrB6/c9UYIAAAgOxAAAIAANYhAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWIcABAAArEMAAgAA1iEAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACLDBhwgQJCAiQgQMHusqOHDkinTt3lpIlS0poaKg8/fTTcu7cOa8uJ3IO+wDgjgAE+LmdO3fKzJkzpW7duq6yq1evStu2bc0Bcd26dbJlyxa5efOmPPHEE5KSkuLV5UX2Yx8AbkcAAvzYlStXpFu3bjJr1iwpWrSoq1wPdseOHZO5c+dKnTp1zGPevHmya9cuczCE/2AfADwjAAF+rF+/fhIVFSURERFu5YmJieabf0hIiKssX758EhgYKJs3b/bCkiKnsA8AnhGAAD+1aNEi2bNnj0RHR982rUmTJlKwYEEZNmyYXLt2zXSHDBkyRJKTk+XMmTNeWV5kP/YBIGMEIMAPnTx5UgYMGCALFiww3+rT00GvixcvlmXLlkmhQoWkSJEiEhcXJ/Xr1zctAMj92AeAzAX9ynQAudDu3bvl/Pnz5mDm0G/2mzZtkvfff990f+gAWD0L6OLFixIUFCRhYWFSpkwZqVq1qleXHdmDfQDIHAEI8ENt2rSRffv2uZX17NlTatSoYbo88uTJ4yovUaKEedaBr3rA7NChw11fXmQ/9gEgcwQgwA8VLlxYateu7Vam4z2KFy/uKp8zZ47UrFnTdIVs27bNdJcMGjRIqlev7qWlRnZiHwAyRwACLHXw4EEZPny4xMbGSuXKleWNN94wBz/Yg30ANgtITU1N9fZC+KKEhAQzKDA+Pt5cITU7VX7tX2K7YxOivL0IAOBVth8LjuXQcSCrx2+G+gMAAOsQgAAAgHUIQAAAwDoMgga8gL5/xoCxD7APwLtoAQIAANYhAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWIcABAAArEMAAgAA1iEAAQAA6xCAAACAdQhAAADAOgQgAABgHQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAAIB1CEAAAMA6BCAAAGAdAhAAALAOAQgAAFiHAAQAAKxDAAIAANYhAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWMevA9C0adOkcuXKki9fPmncuLHs2LHD24sEAAB8gN8GoM8++0wGDx4so0ePlj179sgDDzwgkZGRcv78eW8vGgAA8DK/DUDvvPOO9O7dW3r27Cm1atWSGTNmSIECBWT27NneXjQAAOBlQeKHbt68Kbt375bhw4e7ygIDAyUiIkK2bdvm8W8SExPNwxEfH2+eY2Nj5datW67/kSdPHklOTpaUlBS3/63lSUlJkpqa6irXMp2Wvjwl8ZrYzlm/um7SCg4ONutW17EjICBAgoKCMizPaHv83u3klDvb36Gv6WnZMyr3VCfb94FLly7liu2Uk/se+8ClXLGdcnLfYx+4lCPbSY/bKu00awLQxYsXzQorXbq0W7n+fuDAAY9/Ex0dLWPGjLmtvEqVKjm2nDYLm+rtJYA3lWD7W499ACVyeB+4fPmyFClSxK4AdCe0tUjHDDk0bWqKLF68uEmn/iIhIUEqVKggJ0+elNDQUG8vDryAfQDsA0jw431AW340/JQrVy7T+fwyAJUoUcI0hZ07d86tXH8vU6aMx78JCQkxj7TCwsLEX+kO7287PX4b9gGwDyDUT/eBzFp+/HoQdN68eaVBgwaydu1atxYd/b1p06ZeXTYAAOB9ftkCpLQ7q0ePHtKwYUNp1KiRTJ06Va5evWrOCgMAAHbz2wD0zDPPyIULF2TUqFFy9uxZCQ8Pl5UrV942MNo22s2n10ZK390He7APgH0AIewDEpD6a+eJAQAA+Bm/HAMEAACQGQIQAACwDgEIAABYhwAEAACsQwACAADWIQABAADrEIAAwGLOlVC4Igpsw3WALKX3RTt69Ki5bYiqVKmSufEr7KC3hgkM5PsPbuccEvzpJtCAJwQgC82aNUvmzJkje/bskaCgIKlVq5bUqFFDmjdvLlFRUVK+fHkOkJbQt78+2NZ2WrFihfzvf/+TpKQkKVmypDRu3JgvQrAGAcgyly5dkmrVqkm/fv2kd+/ekpCQYD4E9Uaxhw8fljp16siUKVOkSpUq5sDIt0D/oge7+vXrS5cuXcx98e6//37XNA29ur31cfDgQSlbtqxf3iUaIpcvX5aXX35Z1qxZY8JPuXLlpFChQib8tGzZUp5++mnTKsxngP9KSkqS2NhYKVWqlNiKr32WWbBggfzhD3+QcePGScWKFaV27dry6quvyqpVq+TDDz+U06dPy+OPPy5xcXF88Pmhjz/+WI4fP24OfBp2tfVv8uTJpktUW4F0m//3v/+VZ599Vi5evOjtxUUOeffdd2Xfvn3yxRdfmIPgokWLTCAuWrSo+YzQz4T4+Hg+A/zY+++/L9WrV5f+/fvLt99+K9euXbttHv2C/PXXX8utW7fEHxGALBMcHCxXrlyRAwcOmN9v3LghN2/eND+3atVK5s+fb74Z6AES/mfv3r2m5W/ZsmWyefNmiYiIkPfee8+0AOg3fz0Q6kHx3//+t1StWtXbi4scoge1Xr16ycMPP2x+1y9CL730knn/T5o0SbZv3y4vvPCCtxcTOejTTz81X4C+++47895v0KCB/PWvf5Uff/xRkpOTzTwahseMGWOOG/6IAGSZp556ynzT14Oehp98+fKZgdDa/aF0LJA2g2srAfxLYmKi6fKqXLmyaf1r1qyZ6e7UD0ANPWXKlDHfBgcNGiTDhg3z9uIih+i3ed0PlixZYrrElX7p0YOefja0bdtWpk2bZrrE9WAI/3PhwgXzud+3b1/ZsWOH2c6dO3eWuXPnSnh4uDzyyCMyY8YMmT59uhkX5q8YA2QRZ4yHfvANGDDANG8+88wz5k1Qr149OXPmjGzYsEH69Oljmsf1QAn/C0F60NMWn/QD3fXA+M0335iB8CdPnpR77rnHq8uKnKMtPN27dzddnQMHDrxt4LN2g+qXIR0Lxn7gf/SzftGiRSYIa+B1aAjeunWrzJ492xwn9Bhx4sQJc2KMPyIAWXoQPHLkiGzcuFG+/PJL0xWiwUg/6PQg2K1bNxk7dqy3FxM5+OGn3/48ne2jY8P0DMH//Oc/Xlk25Dz9yNcWH93Or7/+ujno6aDn5557zgx8jomJka+++sp8Cdq1a5e3Fxc55Pr16+Y5f/78Hge7DxkyRNatW2fOFvZXBCBL6IDWzz77zAx41QNfsWLFzIDHRo0amdYfHQCnB7127dqZs8QY/Oif2/+tt94ypzvr2V3aCtShQwfT4qMfgtoipAPhtVwHwsP/6ckO2u2xcOFCE3yKFCliusX1TMHhw4dLkyZNvL2I8IIbN26YrjAdGO/P3eEEIEu8+OKL8sMPP5iAo6e7ajeI9vGfOnXKfOvTgW46IA7+v/0LFy5stv/PP/9suro08A4ePFiaNm3q7cXEXfjWr2E3LT0EaLmeHKGtPvr54M/jPmznaR/wNM8///lP0yroXCzXHxGALKCbWD/U9Ho/OrjNKdMApKc/6rd+PRX2888/N2eDwI7tr92guv31wph6yrN+4KW9LhD8z1/+8hdzwVM940cHvYeEhHi8VpS2DnMNIHv3gbi4OAkLCxN/x1lgFvjpp5/MKc0FCxZ0lekHm37z15YBvQiivgk0AMGe7X/fffeZJm7d/npF8MWLF3t1OZGztJtLz/rTgc96yQvt4lq/fr25BpRznRcd9Kr7hLYEEX7s2QfOnz9vxoWpq1evyvPPP2/FGYC0AFlAmzN1TIfu4Nrfr2d3pf9we+edd8ybg0GP/oftD/XnP//ZdGfo4Fa9Boy2/OrlLnQMoF4eIzIy0owD0rNA/fXCd7ZjH3BHC5AFtL93/Pjx5tudnvqqBzo9E8g5C0DPCtPTYvWqoPA/bH9o+NVWQO3W0Oc33njD3AxZD3YNGzaUCRMmSIsWLczFEHUfgf9hH7gdLUAW0WZtPc1ZrwKsY0Ieeugh0west8EoUaKE+TZQt25dby8mcgjb3246rkO7uzTo6tXf9eq+aVsC9aq/euD7/vvv5YEHHvDqsiJnsA+4IwBZSPt7ly9fLkuXLjWtAzrwuWvXrlKzZk1vLxruArY/HHrpAz0E5MmTxwyG1wukeronFPxXisX7AAHIcumvBgy7sP2RdhyYXhRx6NCh3l4UeMk7lu0DBCAAgBn0qq0ABGJ73bJsHyAAAQAA69gR8wAAANIgAAEAAOsQgAAAgHUIQAAAwDoEIAAAYB0CEAAAsA4BCAAAWIcABAAAxDb/B1eyXeYLJw1NAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "plot_histogram(counts)"
    ]
@@ -76,9 +166,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (helmi)",
+   "display_name": "fiqciex",
    "language": "python",
-   "name": "helmi"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -90,7 +180,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/qiskit/bell_state.ipynb
+++ b/qiskit/bell_state.ipynb
@@ -9,7 +9,6 @@
     "import os\n",
     "from iqm.qiskit_iqm import IQMProvider\n",
     "from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis\n",
-    "from qiskit.compiler import transpile\n",
     "from qiskit import QuantumCircuit, transpile\n",
     "from qiskit.visualization import plot_histogram"
    ]

--- a/qiskit/bell_states_qiskit.py
+++ b/qiskit/bell_states_qiskit.py
@@ -7,6 +7,7 @@ from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
 from qiskit_aer import Aer
 
 from qiskit import QuantumCircuit, QuantumRegister, transpile
+
 """
 Create and measure a bell state. User lists the pairs to entangle.
 

--- a/qiskit/bell_states_qiskit.py
+++ b/qiskit/bell_states_qiskit.py
@@ -4,8 +4,9 @@ from argparse import RawTextHelpFormatter
 
 from iqm.qiskit_iqm import IQMProvider
 from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
-from qiskit import QuantumCircuit, QuantumRegister, transpile
 from qiskit_aer import Aer
+
+from qiskit import QuantumCircuit, QuantumRegister, transpile
 
 """
 Create and measure a bell state. User lists the pairs to entangle.
@@ -17,11 +18,13 @@ Compare simulator vs real devices. CNOT gate on different target/control qubits 
 
 """
 
+
 def print_header(s):
     """
     Prints a section header.
     """
     print("\n" + f"=== {s.upper()} ===")
+
 
 def get_args():
 
@@ -72,8 +75,10 @@ def main():
         # Set up the Helmi backend
         HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
         if not HELMI_CORTEX_URL:
-            print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
-            #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+            print("""Environment variable HELMI_CORTEX_URL is not set.
+                  Are you running on Lumi and on the q_fiqci node?.
+                  Falling back to fake backend.""")
+            # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
         else:
             provider = IQMProvider(HELMI_CORTEX_URL)
@@ -104,7 +109,10 @@ def main():
             qreg[1]: 2,
         }
 
-        qc = transpile(qc, backend, optimization_level=0, initial_layout=qubit_mapping)
+        qc = transpile(
+            qc, backend, optimization_level=0,
+            initial_layout=qubit_mapping,
+        )
 
         if args.verbose:
             print(qc.draw())
@@ -119,8 +127,6 @@ def main():
                 print(job.result().results[0].metadata['input_qubit_map'])
             except AttributeError:
                 print(job.result().request.qubit_mapping)
-
-
 
         t2 = ((counts.get("00", 0) + counts.get("11", 0)) / shots) * 100
 
@@ -160,8 +166,11 @@ def main():
             qreg[1]: 2,
         }
 
-        qc = transpile(qc, backend, optimization_level=0, initial_layout=qubit_mapping)
-        
+        qc = transpile(
+            qc, backend, optimization_level=0,
+            initial_layout=qubit_mapping,
+        )
+
         if args.verbose:
             print(qc.draw())
 

--- a/qiskit/bernstein_vazirani.py
+++ b/qiskit/bernstein_vazirani.py
@@ -6,8 +6,10 @@ from random import randint
 
 from iqm.qiskit_iqm import IQMProvider
 from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qiskit_aer import Aer
+
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
+
 """
 
 This example shows the Bernstein-Vazirani Algorithm.
@@ -26,6 +28,7 @@ This is a 5 qubit circuit with the last qubit used as an "output qubit". Hence o
 of size 4 despite having a quantum register of size 5.
 
 """
+
 
 class BVoracle:
     """
@@ -78,7 +81,9 @@ class BVoracle:
             qc.h(i)
 
         qc.measure(range(4), range(4))
-        transpiled_circuit = transpile(qc, self.backend, layout_method='sabre', optimization_level=3)
+        transpiled_circuit = transpile(
+            qc, self.backend, layout_method='sabre', optimization_level=3,
+        )
         if self.verbose:
             print("Created circuit: ")
             print(qc.draw())
@@ -195,6 +200,7 @@ def print_header(s):
     """
     print("\n" + f"=== {s.upper()} ===")
 
+
 def most_frequent(lst):
     """
     Returns the most frequent item in a list.
@@ -202,6 +208,7 @@ def most_frequent(lst):
     freqs = Counter(lst)
     most_freq_item = max(freqs, key=freqs.get)
     return most_freq_item, freqs[most_freq_item]
+
 
 def secret_count(lst, secret):
     """
@@ -217,8 +224,10 @@ def main():
         # Set up the Helmi backend
         HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
         if not HELMI_CORTEX_URL:
-            print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
-            #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+            print("""Environment variable HELMI_CORTEX_URL is not set.
+                  Are you running on Lumi and on the q_fiqci node?.
+                  Falling back to fake backend.""")
+            # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
         else:
             provider = IQMProvider(HELMI_CORTEX_URL)

--- a/qiskit/first_quantum_job.py
+++ b/qiskit/first_quantum_job.py
@@ -21,13 +21,17 @@ circuit.measure_all()
 backend = IQMFakeAdonis()
 HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
 if not HELMI_CORTEX_URL:
-    print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
-    #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+    print("""Environment variable HELMI_CORTEX_URL is not set.
+          Are you running on Lumi and on the q_fiqci node?.
+          Falling back to fake backend.""")
+    # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
 else:
     provider = IQMProvider(HELMI_CORTEX_URL)
     backend = provider.get_backend()
-    circuit = transpile(circuit, backend, layout_method='sabre', optimization_level=3)
+    circuit = transpile(
+        circuit, backend, layout_method='sabre', optimization_level=3,
+    )
 
 # Retrieving backend information
 # print(f'Native operations: {backend.operation_names}')
@@ -46,7 +50,7 @@ try:
 except AttributeError:
     print(job.result().request.qubit_mapping)
 """
-#print(result.results[0].shots)
+# print(result.results[0].shots)
 
 counts = result.get_counts()
 print(counts)

--- a/qiskit/first_quantum_job.py
+++ b/qiskit/first_quantum_job.py
@@ -1,8 +1,9 @@
 import os
 
 from iqm.qiskit_iqm import IQMProvider
+from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
 
-from qiskit import QuantumCircuit, QuantumRegister, execute
+from qiskit import QuantumCircuit, QuantumRegister, transpile
 
 shots = 1000
 
@@ -16,28 +17,36 @@ circuit.measure_all()
 # Uncomment if you wish to print the circuit
 # print(circuit.draw())
 
+# Set up the Helmi backend
+backend = IQMFakeAdonis()
 HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
 if not HELMI_CORTEX_URL:
-    raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+    print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
+    #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
-provider = IQMProvider(HELMI_CORTEX_URL)
-backend = provider.get_backend()
+else:
+    provider = IQMProvider(HELMI_CORTEX_URL)
+    backend = provider.get_backend()
+    circuit = transpile(circuit, backend, layout_method='sabre', optimization_level=3)
 
 # Retrieving backend information
 # print(f'Native operations: {backend.operation_names}')
 # print(f'Number of qubits: {backend.num_qubits}')
 # print(f'Coupling map: {backend.coupling_map}')
 
-job = execute(circuit, backend, shots=shots)
+job = backend.run(circuit, shots=shots)
 result = job.result()
 exp_result = job.result()._get_experiment(circuit)
 # You can retrieve the job at a later date with backend.retrieve_job(job_id)
 # Uncomment the following lines to get more information about your submitted job
 print("Job ID: ", job.job_id())
-# print(result.request.circuits)
-print("Calibration Set ID: ", exp_result.calibration_set_id)
-# print(result.request.qubit_mapping)
-# print(result.request.shots)
+"""
+try:
+    print(job.result().results[0].metadata['input_qubit_map'])
+except AttributeError:
+    print(job.result().request.qubit_mapping)
+"""
+#print(result.results[0].shots)
 
 counts = result.get_counts()
 print(counts)

--- a/qiskit/ghz.py
+++ b/qiskit/ghz.py
@@ -5,8 +5,9 @@ from argparse import RawTextHelpFormatter
 import numpy as np
 from iqm.qiskit_iqm import IQMProvider
 from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
-from qiskit import QuantumCircuit, QuantumRegister, transpile
 from qiskit_aer import Aer
+
+from qiskit import QuantumCircuit, QuantumRegister, transpile
 
 """
 
@@ -28,11 +29,14 @@ and then the 5 qubit GHZ state
     or Kolmogorov distance
     It is another measure of the distinguishability between two quantum states
 """
+
+
 def print_header(s):
     """
     Prints a section header.
     """
     print("\n" + f"=== {s.upper()} ===")
+
 
 def get_args():
 
@@ -81,8 +85,10 @@ def main():
         # Set up the Helmi backend
         HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
         if not HELMI_CORTEX_URL:
-            print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
-            #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+            print("""Environment variable HELMI_CORTEX_URL is not set.
+                  Are you running on Lumi and on the q_fiqci node?.
+                  Falling back to fake backend.""")
+            # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
         else:
             provider = IQMProvider(HELMI_CORTEX_URL)
@@ -91,12 +97,11 @@ def main():
         provider = Aer
         backend = provider.get_backend('aer_simulator')
 
-
     shots = 10000
 
     bell_vd = []
     id_dist = [0.5, 0, 0, 0.5]
-    
+
     print_header("Preparing a Bell State")
     count = 0
     for qb in [0, 1, 3, 4]:
@@ -119,7 +124,9 @@ def main():
         }   # map second virtual qubit to QB3
 
         # Run job on the circuit
-        circuit = transpile(circuit, backend, optimization_level=0, initial_layout=mapping)
+        circuit = transpile(
+            circuit, backend, optimization_level=0, initial_layout=mapping,
+        )
         job = backend.run(circuit, shots=shots)
         counts = job.result().get_counts()
 
@@ -167,7 +174,9 @@ def main():
         print(" ")
         print(circuit.draw())
 
-    circuit = transpile(circuit, backend, layout_method="sabre", optimization_level=3)
+    circuit = transpile(
+        circuit, backend, layout_method="sabre", optimization_level=3,
+    )
     job = backend.run(circuit, shots=shots)
     counts = job.result().get_counts()
 

--- a/qiskit/ghz.py
+++ b/qiskit/ghz.py
@@ -8,6 +8,7 @@ from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
 from qiskit_aer import Aer
 
 from qiskit import QuantumCircuit, QuantumRegister, transpile
+
 """
 
 This example creates a 5 qubit GHZ state in qiskit

--- a/qiskit/ghz.py
+++ b/qiskit/ghz.py
@@ -4,11 +4,13 @@ from argparse import RawTextHelpFormatter
 
 import numpy as np
 from iqm.qiskit_iqm import IQMProvider
-from qiskit_aer import Aer, QuantumCircuit, QuantumRegister, execute
+from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
+from qiskit import QuantumCircuit, QuantumRegister, transpile
+from qiskit_aer import Aer
 
 """
 
-This example creates a 5 qubit GHZ stats in cirq
+This example creates a 5 qubit GHZ state in qiskit
 
 First a Bell state is prepared between QB3 and all the other qubits.
 From this we can measure the trace distance between QB3 and each of the other qubits.
@@ -26,7 +28,11 @@ and then the 5 qubit GHZ state
     or Kolmogorov distance
     It is another measure of the distinguishability between two quantum states
 """
-
+def print_header(s):
+    """
+    Prints a section header.
+    """
+    print("\n" + f"=== {s.upper()} ===")
 
 def get_args():
 
@@ -69,37 +75,32 @@ def get_args():
 
 
 def main():
-    offset = " " * 37
-    offset_2 = " " * 10
-    offset_3 = " " * 15
-
     args = get_args()
-
+    backend = IQMFakeAdonis()
     if args.backend == 'helmi':
+        # Set up the Helmi backend
         HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
         if not HELMI_CORTEX_URL:
-            raise ValueError(
-                "Environment variable HELMI_CORTEX_URL is not set",
-            )
-        provider = IQMProvider(HELMI_CORTEX_URL)
-        backend = provider.get_backend()
+            print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
+            #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+
+        else:
+            provider = IQMProvider(HELMI_CORTEX_URL)
+            backend = provider.get_backend()
     else:
         provider = Aer
         backend = provider.get_backend('aer_simulator')
+
 
     shots = 10000
 
     bell_vd = []
     id_dist = [0.5, 0, 0, 0.5]
-
-    print(" ")
-    print(offset + "================================ ")
-    print(offset + "    Preparing a Bell State")
-    print(offset + "================================ ")
-    print(" ")
+    
+    print_header("Preparing a Bell State")
     count = 0
     for qb in [0, 1, 3, 4]:
-        print(offset + "QB" + str(qb + 1) + " and QB3 -> ", end=" ")
+        print("QB" + str(qb + 1) + " and QB3 -> ", end=" ")
         qreg = QuantumRegister(2, "qB")
         circuit = QuantumCircuit(qreg)
 
@@ -118,13 +119,17 @@ def main():
         }   # map second virtual qubit to QB3
 
         # Run job on the circuit
-        job = execute(circuit, backend, shots=shots, initial_layout=mapping)
+        circuit = transpile(circuit, backend, optimization_level=0, initial_layout=mapping)
+        job = backend.run(circuit, shots=shots)
         counts = job.result().get_counts()
 
         if args.verbose:
-            print(counts)
+            print(f"Counts: {counts}")
             if "IQM" in str(backend):
-                print(job.result().request.qubit_mapping)
+                try:
+                    print(job.result().results[0].metadata['input_qubit_map'])
+                except AttributeError:
+                    print(job.result().request.qubit_mapping)
 
         values = counts.values()
         values_list = list(values)
@@ -139,19 +144,11 @@ def main():
         bell_vd.append(vd)
 
         print("Fidelity = ", round(fid1, 3))
-        print(offset_2 + offset_3, end=" ")
-        print(
-            offset_3 +
-            "Distance from target ([0,1]) = ", round(bell_vd[count], 3),
-        )
+        print("Distance from target ([0,1]) = ", round(bell_vd[count], 3))
 
         count += 1
 
-    print(" ")
-    print(offset + "================================ ")
-    print(offset + "    Preparing a GHZ-5 State")
-    print(offset + "================================ ")
-    print(" ")
+    print_header("Preparing a GHZ-5 State")
 
     id_dist = [0 for i in range(32)]
     id_dist[0] = 0.5
@@ -170,16 +167,17 @@ def main():
         print(" ")
         print(circuit.draw())
 
-    job = execute(circuit, backend, shots=shots)
+    circuit = transpile(circuit, backend, layout_method="sabre", optimization_level=3)
+    job = backend.run(circuit, shots=shots)
     counts = job.result().get_counts()
 
     if args.verbose:
-        print(counts)
+        print(f"Counts: {counts}")
         if "IQM" in str(backend):
-            print(
-                offset + "\n" +
-                job.result().request.qubit_mapping[0].physical_name + "\n",
-            )
+            try:
+                print(job.result().results[0].metadata['input_qubit_map'])
+            except AttributeError:
+                print(job.result().request.qubit_mapping)
 
     values = counts.values()
     values_list = list(values)
@@ -191,8 +189,8 @@ def main():
         vd = 0.5 * vd
         fid2 += np.sqrt((values_list[i] / shots) * id_dist[i])
 
-    print(offset + "GHZ-5 -> Fidelity = ", round(fid2, 3))
-    print(offset + "GHZ-5 -> Distance from target ([0,1]) = ", round(vd, 3))
+    print("GHZ-5 -> Fidelity = ", round(fid2, 3))
+    print("GHZ-5 -> Distance from target ([0,1]) = ", round(vd, 3))
 
     print(" ")
     print(" ")

--- a/qiskit/qb_flip.py
+++ b/qiskit/qb_flip.py
@@ -12,9 +12,6 @@ from qiskit_aer import Aer
 from qiskit import QuantumCircuit, QuantumRegister, transpile
 
 
-from qiskit import QuantumCircuit, QuantumRegister, transpile
-
-
 def get_args():
     parser = argparse.ArgumentParser(
         description="Qubit flipping options", formatter_class=RawTextHelpFormatter,

--- a/qiskit/qb_flip.py
+++ b/qiskit/qb_flip.py
@@ -6,8 +6,9 @@ import os
 from argparse import RawTextHelpFormatter
 
 from iqm.qiskit_iqm import IQMProvider
-from qiskit_aer import Aer, QuantumCircuit, QuantumRegister, execute
-
+from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
+from qiskit import QuantumCircuit, QuantumRegister, transpile
+from qiskit_aer import Aer
 
 def get_args():
     parser = argparse.ArgumentParser(
@@ -67,18 +68,23 @@ def single_flip_circuit(qubit: int) -> tuple[QuantumCircuit, dict]:
     return qc, mapping
 
 
-def flip_qubits(qubits: list[int], backend: str, shots: int, verbose: bool):
+def flip_qubits(qubits: list[int], backend_str: str, shots: int, verbose: bool):
     """
     Function to run the flip circuit
     """
-    if backend == 'helmi':
+
+    backend = IQMFakeAdonis()
+
+    if backend_str == 'helmi':
+        # Set up the Helmi backend
         HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
         if not HELMI_CORTEX_URL:
-            raise ValueError(
-                "Environment variable HELMI_CORTEX_URL is not set",
-            )
-        provider = IQMProvider(HELMI_CORTEX_URL)
-        backend = provider.get_backend()
+            print("Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi? Falling back to a simulator.")
+            #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+
+        else:
+            provider = IQMProvider(HELMI_CORTEX_URL)
+            backend = provider.get_backend()
     else:
         provider = Aer
         backend = provider.get_backend('aer_simulator')
@@ -100,12 +106,15 @@ def flip_qubits(qubits: list[int], backend: str, shots: int, verbose: bool):
             print(f"Circuit {i+1}:\n")
             print(circuit)
 
-        job = execute(circuit, backend, shots=shots, initial_layout=mapping)
+        circuit = transpile(circuit, backend, layout_method='sabre', optimization_level=3, initial_layout=mapping)
+        job = backend.run(circuit, shots=shots)
         counts = job.result().get_counts()
-
         if verbose and "IQM" in str(backend):
             print("Mapping")
-            print(job.result().request.qubit_mapping)
+            try:
+                print(job.result().results[0].metadata['input_qubit_map'])
+            except AttributeError:
+                print(job.result().request.qubit_mapping)
 
         if qubits is None:
             success_probability = calculate_success_probability(

--- a/qiskit/qb_flip.py
+++ b/qiskit/qb_flip.py
@@ -7,8 +7,10 @@ from argparse import RawTextHelpFormatter
 
 from iqm.qiskit_iqm import IQMProvider
 from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
-from qiskit import QuantumCircuit, QuantumRegister, transpile
 from qiskit_aer import Aer
+
+from qiskit import QuantumCircuit, QuantumRegister, transpile
+
 
 def get_args():
     parser = argparse.ArgumentParser(
@@ -79,8 +81,10 @@ def flip_qubits(qubits: list[int], backend_str: str, shots: int, verbose: bool):
         # Set up the Helmi backend
         HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
         if not HELMI_CORTEX_URL:
-            print("Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi? Falling back to a simulator.")
-            #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+            print("""Environment variable HELMI_CORTEX_URL is not set.
+                  Are you running on Lumi and on the q_fiqci node?
+                  Falling back to a simulator.""")
+            # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
         else:
             provider = IQMProvider(HELMI_CORTEX_URL)
@@ -106,7 +110,10 @@ def flip_qubits(qubits: list[int], backend_str: str, shots: int, verbose: bool):
             print(f"Circuit {i+1}:\n")
             print(circuit)
 
-        circuit = transpile(circuit, backend, layout_method='sabre', optimization_level=3, initial_layout=mapping)
+        circuit = transpile(
+            circuit, backend, layout_method='sabre',
+            optimization_level=3, initial_layout=mapping,
+        )
         job = backend.run(circuit, shots=shots)
         counts = job.result().get_counts()
         if verbose and "IQM" in str(backend):

--- a/qiskit/qb_flip_simple.py
+++ b/qiskit/qb_flip_simple.py
@@ -49,8 +49,10 @@ def main():
     backend = IQMFakeAdonis()
     HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
     if not HELMI_CORTEX_URL:
-        print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
-        #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+        print("""Environment variable HELMI_CORTEX_URL is not set.
+              Are you running on Lumi and on the q_fiqci node?.
+              Falling back to fake backend.""")
+        # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
     else:
         provider = IQMProvider(HELMI_CORTEX_URL)
@@ -61,7 +63,10 @@ def main():
     print("\nFlip one qubit at a time\n")
     for qb in range(5):
         circuit, mapping = single_flip_circuit(qb)
-        circuit = transpile(circuit, backend, layout_method='sabre', optimization_level=3, initial_layout=mapping)
+        circuit = transpile(
+            circuit, backend, layout_method='sabre',
+            optimization_level=3, initial_layout=mapping,
+        )
         job = backend.run(circuit, shots=shots)
         counts = job.result().get_counts()
         success_probability = calculate_success_probability(counts, shots, '1')
@@ -73,7 +78,10 @@ def main():
 
     print("\nFlip all qubits at once\n")
     circuit, mapping = flip_circuit([0, 1, 2, 3, 4])
-    circuit = transpile(circuit, backend, layout_method='sabre', optimization_level=3, initial_layout=mapping)
+    circuit = transpile(
+        circuit, backend, layout_method='sabre',
+        optimization_level=3, initial_layout=mapping,
+    )
     job = backend.run(circuit, shots=shots)
     counts = job.result().get_counts()
     success_probability = calculate_success_probability(counts, shots, '11111')

--- a/qiskit/qb_flip_simple.py
+++ b/qiskit/qb_flip_simple.py
@@ -4,8 +4,9 @@ Simple qubit flipping example
 import os
 
 from iqm.qiskit_iqm import IQMProvider
+from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
 
-from qiskit import QuantumCircuit, QuantumRegister, execute
+from qiskit import QuantumCircuit, QuantumRegister, transpile
 
 
 def single_flip_circuit(qubit: int) -> tuple[QuantumCircuit, dict]:
@@ -45,38 +46,39 @@ def calculate_success_probability(counts: dict, shots: int, desired_state: str) 
 
 def main():
 
+    backend = IQMFakeAdonis()
     HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
     if not HELMI_CORTEX_URL:
-        raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
-    provider = IQMProvider(HELMI_CORTEX_URL)
-    backend = provider.get_backend()
+        print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
+        #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+
+    else:
+        provider = IQMProvider(HELMI_CORTEX_URL)
+        backend = provider.get_backend()
 
     shots = 1000
 
     print("\nFlip one qubit at a time\n")
     for qb in range(5):
         circuit, mapping = single_flip_circuit(qb)
-        job = execute(circuit, backend, shots=shots, initial_layout=mapping)
-        # assert that the mapping is correct
-        assert 'QB' + \
-            str(qb+1) == job.result().request.qubit_mapping[0].physical_name
+        circuit = transpile(circuit, backend, layout_method='sabre', optimization_level=3, initial_layout=mapping)
+        job = backend.run(circuit, shots=shots)
         counts = job.result().get_counts()
         success_probability = calculate_success_probability(counts, shots, '1')
         print(
-            f"QB{
+            f"""QB{
                 qb + 1
-            } -> {counts}, Success probability: {success_probability * 100:.2f}%",
+            } -> {counts}, Success probability: {success_probability * 100:.2f}%""",
         )
 
     print("\nFlip all qubits at once\n")
     circuit, mapping = flip_circuit([0, 1, 2, 3, 4])
-    job = execute(circuit, backend, shots=shots, initial_layout=mapping)
+    circuit = transpile(circuit, backend, layout_method='sabre', optimization_level=3, initial_layout=mapping)
+    job = backend.run(circuit, shots=shots)
     counts = job.result().get_counts()
     success_probability = calculate_success_probability(counts, shots, '11111')
     print(
-        f"Counts: {counts}, \nSuccess probability: {
-            success_probability * 100:.2f
-        }%",
+        f"Counts: {counts}, \nSuccess probability: {success_probability * 100:.2f}%",
     )
 
 

--- a/qiskit/two_qubit_bell_state_all_combinations.py
+++ b/qiskit/two_qubit_bell_state_all_combinations.py
@@ -15,8 +15,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from iqm.qiskit_iqm import IQMProvider
 from iqm.qiskit_iqm.fake_backends import IQMFakeAdonis
-from qiskit import QuantumCircuit, QuantumRegister, transpile
 from qiskit_aer import AerSimulator
+
+from qiskit import QuantumCircuit, QuantumRegister, transpile
 
 SIMULATE = False
 SHOTS = 1000
@@ -49,8 +50,10 @@ if SIMULATE:
 else:
     HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
     if not HELMI_CORTEX_URL:
-        print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
-        #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
+        print("""Environment variable HELMI_CORTEX_URL is not set.
+              Are you running on Lumi and on the q_fiqci node?.
+              Falling back to fake backend.""")
+        # raise ValueError("Environment variable HELMI_CORTEX_URL is not set")
 
     else:
         provider = IQMProvider(HELMI_CORTEX_URL)
@@ -64,7 +67,9 @@ for idx, (qubit_a, qubit_b) in enumerate(qubit_combinations):
         qreg[0]: qubit_a,
         qreg[1]: qubit_b,
     }
-    tr_circuit = transpile(circuit, backend, optimization_level=0, initial_layout=qubit_mapping)
+    tr_circuit = transpile(
+        circuit, backend, optimization_level=0, initial_layout=qubit_mapping,
+    )
     job = backend.run(tr_circuit, shots=SHOTS)
     counts = job.result().get_counts()
     end_time = time.time() - start_time

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,9 +6,9 @@ This is an example of how to get the figures of merit or quality metrics set fro
 
 ## `int_job.sh`
 
-Simple script to clear the terminal and run an interactive job. Run with `bash int_job.sh 'qb_flip_qiskit.py --backend helmi'` or edit it for your own usage!
+Simple script to clear the terminal and run an interactive job. Run with `bash int_job.sh 'qb_flip_qiskit.py --backend helmi'` or edit it for your own usage! Note that you need to replace the 'project_xxx' with your LUMI project id.
 
 
 ## `batch_script.sh`
 
-Example batch script for submitting jobs to the `q_fiqci` partition. Run with `sbatch batch_script 'qb_flip_qiskit.py --backend helmi'` or edit it for your own usage!
+Example batch script for submitting jobs to the `q_fiqci` partition. Run with `sbatch batch_script 'qb_flip_qiskit.py --backend helmi'` or edit it for your own usage! Note that you need to replace the 'project_xxx' with your LUMI project id.

--- a/scripts/get_calibration_data.py
+++ b/scripts/get_calibration_data.py
@@ -44,7 +44,7 @@ def get_calibration_data(client: IQMClient, calibration_set_id=None, filename: s
 
 HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
 if not HELMI_CORTEX_URL:
-    raise ValueError('Environment variable HELMI_CORTEX_URL is not set')
+    raise ValueError('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?')
 
 # Using Qiskit as an example of how to query using this function.
 

--- a/scripts/get_calibration_data.py
+++ b/scripts/get_calibration_data.py
@@ -44,7 +44,9 @@ def get_calibration_data(client: IQMClient, calibration_set_id=None, filename: s
 
 HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
 if not HELMI_CORTEX_URL:
-    raise ValueError('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?')
+    raise ValueError(
+        'Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?',
+    )
 
 # Using Qiskit as an example of how to query using this function.
 


### PR DESCRIPTION
Update the Qiskit example scripts to qiskit-iqm 15.6 (qiskit 1.1.2, qiskit-experiments 0.7.0).

<h1>List of changes:</h1>

- migrate from execute() to transpile() and run()
- Don't raise an error if HELMI_CORTEX_URL is not found but instead fallback to FakeAdonis. Allows for local testing in a Helmi-like environment. Also, update the printed message to be more informative. New code below.
```python
if args.backend == 'helmi':
        # Set up the Helmi backend
        HELMI_CORTEX_URL = os.getenv('HELMI_CORTEX_URL')
        if not HELMI_CORTEX_URL:
            print('Environment variable HELMI_CORTEX_URL is not set. Are you running on Lumi and on the q_fiqci node?. Falling back to fake backend.')
            #raise ValueError("Environment variable HELMI_CORTEX_URL is not set")

        else:
            provider = IQMProvider(HELMI_CORTEX_URL)
            backend = provider.get_backend()
    else:
        provider = Aer
        backend = provider.get_backend('aer_simulator')
```

- Note that the get_calibration_data.py still raises an error if the HELMI_CORTEX_URL  since it needs access to the actual backend.

- Make verbose modes also work locally. Hence why some scripts now have a try expect blocks for some prints. This is due to differences in the metadata structures of FakeAdnonis and Helmi.
- Update state tomography to qiskit-experiments 0.7.0. Added a note about the version since pip will by default install a newer version which will not work.
- Fixed some typos all around
- Made formatting of printed results more constant across scripts


All scripts on Helmi have been tested in verbose mode and run properly. Helmis calibration seems to be quite bad so currently couldn't validate the quality of the results but since I didn't change any of the actual circuit logic they should be good,



